### PR TITLE
Fix async status update and add failure test

### DIFF
--- a/src/app/routes.py
+++ b/src/app/routes.py
@@ -78,7 +78,8 @@ def register_routes(app: Flask) -> None:
                     except Exception:
                         # If generation fails, mark as failed
                         try:
-                            update_package_status(id, "failed")
+                            with app.app_context():
+                                update_package_status(id, "failed")
                         except Exception:
                             pass
 

--- a/tests/test_generate_script_async_failure.py
+++ b/tests/test_generate_script_async_failure.py
@@ -1,0 +1,26 @@
+from unittest.mock import patch
+
+from src.app import create_app
+from src.app.database import get_database_service, create_package, get_package
+
+
+def test_generate_script_async_failure_marks_failed(tmp_path):
+    app = create_app({"DATABASE_URL": f"sqlite:///{tmp_path / 'test.db'}"})
+    app.instance_path = str(tmp_path)
+
+    with app.app_context():
+        db_service = get_database_service()
+        db_service.create_tables()
+        pkg = create_package("test.msi", str(tmp_path / "test.msi"))
+        pkg_id = str(pkg.id)
+
+    client = app.test_client()
+
+    with patch("requests.post", side_effect=Exception("boom")):
+        with patch("threading.Thread.start", lambda self: self.run()):
+            client.get(f"/progress/{pkg_id}")
+
+    with app.app_context():
+        refreshed = get_package(pkg_id)
+        assert refreshed is not None
+        assert refreshed.status == "failed"


### PR DESCRIPTION
## Summary
- ensure update_package_status in `/progress/<id>` runs inside an application context
- add regression test covering failed script generation

## Testing
- `ruff format tests/test_generate_script_async_failure.py src/app/routes.py`
- `ruff check tests/test_generate_script_async_failure.py src/app/routes.py`
- `mypy src/app/routes.py`
- `python -m pytest -q tests/test_generate_script_async_failure.py`
- `pre-commit run --files src/app/routes.py tests/test_generate_script_async_failure.py` *(fails: CONNECT tunnel failed)*
- `python -m pytest -q` *(fails: many tests)*

------
https://chatgpt.com/codex/tasks/task_e_685cefaa7d9883278e70babd46f28ada