### PR TITLE
Handle predicted_processes_to_close

### DIFF
--- a/src/app/schemas.py
+++ b/src/app/schemas.py
@@ -8,6 +8,7 @@ class InstructionResult(BaseModel):
 
     structured_instructions: Dict[str, Any]
     predicted_cmdlets: List[str]
+    predicted_processes_to_close: Optional[List[str]] = None
     confidence_score: float
 
 

--- a/src/app/services/instruction_processor.py
+++ b/src/app/services/instruction_processor.py
@@ -63,6 +63,9 @@ class InstructionProcessor:
                     "structured_instructions", {}
                 ),
                 predicted_cmdlets=response_data.get("predicted_cmdlets", []),
+                predicted_processes_to_close=response_data.get(
+                    "predicted_processes_to_close"
+                ),
                 confidence_score=response_data.get("confidence_score", 0.8),
             )
         except (json.JSONDecodeError, KeyError):
@@ -77,5 +80,6 @@ class InstructionProcessor:
                     "Show-ADTInstallationWelcome",
                     "Show-ADTInstallationProgress",
                 ],
+                predicted_processes_to_close=None,
                 confidence_score=0.7,
             )

--- a/tests/test_instruction_processor.py
+++ b/tests/test_instruction_processor.py
@@ -1,0 +1,31 @@
+import json
+from unittest.mock import MagicMock, patch
+
+from src.app.services.instruction_processor import InstructionProcessor
+
+
+def test_process_instructions_extracts_predicted_processes():
+    response_json = json.dumps(
+        {
+            "structured_instructions": {"primary_action": "install"},
+            "predicted_cmdlets": ["Start-ADTMsiProcess"],
+            "predicted_processes_to_close": ["chrome.exe", "teams.exe"],
+            "confidence_score": 0.95,
+        }
+    )
+
+    mock_message = MagicMock()
+    mock_message.content = response_json
+    mock_choice = MagicMock(message=mock_message)
+    mock_response = MagicMock(choices=[mock_choice])
+
+    mock_client = MagicMock()
+    mock_client.api_key = "dummy"
+    mock_client.chat.completions.create.return_value = mock_response
+
+    with patch("src.app.services.instruction_processor.OpenAI", return_value=mock_client):
+        processor = InstructionProcessor()
+        result = processor.process_instructions("Install")
+
+    assert result.predicted_processes_to_close == ["chrome.exe", "teams.exe"]
+    assert result.predicted_cmdlets == ["Start-ADTMsiProcess"]


### PR DESCRIPTION
## Summary
- expose predicted_processes_to_close in InstructionResult
- parse the field in InstructionProcessor
- add unit test for parsing predicted_processes_to_close

## Testing
- `PYTHONPATH=. pytest -q` *(fails: RuntimeError: Unable to build URLs outside an active request without 'SERVER_NAME' configured)*

------
https://chatgpt.com/codex/tasks/task_e_685ff299626c8327b1985b849b2dc893