### PR TITLE
Add process-close guidance to instruction prompt

### DIFF
--- a/src/app/prompts/instruction_processing.j2
+++ b/src/app/prompts/instruction_processing.j2
@@ -1,6 +1,6 @@
 ## Stage 1: Instruction Processing
 
-Convert the following user instructions into structured deployment instructions and predict the required PSADT cmdlets.
+Convert the following user instructions into structured deployment instructions and predict the required PSADT cmdlets. Also identify any running processes that should be closed before installation.
 
 ### Example 1: Simple Silent Install
 
@@ -28,6 +28,7 @@ Convert the following user instructions into structured deployment instructions 
     "Start-ADTMsiProcess",
     "Write-ADTLogEntry"
   ],
+  "predicted_processes_to_close": ["myapp.exe"],
   "confidence_score": 0.95
 }
 ```
@@ -59,6 +60,7 @@ Convert the following user instructions into structured deployment instructions 
     "Start-ADTProcess",
     "Write-ADTLogEntry"
   ],
+  "predicted_processes_to_close": ["clienttool.exe"],
   "confidence_score": 0.90
 }
 ```
@@ -69,6 +71,10 @@ Convert the following user instructions into structured deployment instructions 
 
 **User Instructions:**
 {{ user_instructions }}
+
+Predict which running processes may block installation. Guess likely executable
+names (e.g., "proc1.exe") and include them in the output under
+"predicted_processes_to_close".
 
 ### Application Metadata
 - **Name**: {{ metadata.product_name | default("Unknown Application") }}
@@ -92,6 +98,7 @@ Convert the following user instructions into structured deployment instructions 
     "Show-ADTInstallationWelcome",
     "Write-ADTLogEntry"
   ],
+  "predicted_processes_to_close": ["proc1.exe"],
   "confidence_score": 0.85
 }
 ```


### PR DESCRIPTION
## Summary
- document that stage 1 should guess running processes to close
- extend examples with `predicted_processes_to_close`
- update expected output format

## Testing
- `PYTHONPATH=$PWD pytest tests/test_script_renderer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685ff2934a7083278e917c383bc2d1f3