### PR TITLE
Handle predicted processes in InstructionResult

### DIFF
--- a/src/app/schemas.py
+++ b/src/app/schemas.py
@@ -9,6 +9,7 @@ class InstructionResult(BaseModel):
     structured_instructions: Dict[str, Any]
     predicted_cmdlets: List[str]
     confidence_score: float
+    predicted_processes_to_close: Optional[List[str]] = None
 
 
 class PSADTScript(BaseModel):

--- a/src/app/services/instruction_processor.py
+++ b/src/app/services/instruction_processor.py
@@ -39,7 +39,11 @@ class InstructionProcessor:
                 messages=[
                     {
                         "role": "system",
-                        "content": "You are an expert in PowerShell and PSAppDeployToolkit. Return a JSON object with structured_instructions, predicted_cmdlets, and confidence_score.",
+                        "content": (
+                            "You are an expert in PowerShell and PSAppDeployToolkit. "
+                            "Return a JSON object with structured_instructions, predicted_cmdlets, "
+                            "predicted_processes_to_close, and confidence_score."
+                        ),
                     },
                     {"role": "user", "content": prompt},
                 ],
@@ -64,6 +68,9 @@ class InstructionProcessor:
                 ),
                 predicted_cmdlets=response_data.get("predicted_cmdlets", []),
                 confidence_score=response_data.get("confidence_score", 0.8),
+                predicted_processes_to_close=response_data.get(
+                    "predicted_processes_to_close"
+                ),
             )
         except (json.JSONDecodeError, KeyError):
             # Fallback for failed parsing
@@ -78,4 +85,5 @@ class InstructionProcessor:
                     "Show-ADTInstallationProgress",
                 ],
                 confidence_score=0.7,
+                predicted_processes_to_close=None,
             )

--- a/tests/test_pipeline_full.py
+++ b/tests/test_pipeline_full.py
@@ -67,6 +67,7 @@ def test_full_pipeline_flow(app_with_db):
             structured_instructions={"user_instructions": "Install"},
             predicted_cmdlets=["Start-ADTMsiProcess"],
             confidence_score=0.9,
+            predicted_processes_to_close=None,
         )
         data = {"installer": (BytesIO(b"abc"), "dummy.msi")}
         resp = client.post("/api/packages", data=data)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -23,6 +23,7 @@ def mock_services():
                 structured_instructions={"install": "test"},
                 predicted_cmdlets=["Install-MSI"],
                 confidence_score=0.9,
+                predicted_processes_to_close=["app1.exe"],
             )
         )
 


### PR DESCRIPTION
## Summary
- add `predicted_processes_to_close` to `InstructionResult`
- parse `predicted_processes_to_close` in `InstructionProcessor`
- update test mocks to include this new field

## Testing
- `pytest tests/test_services.py -q`
- `pytest tests/test_pipeline_full.py -q` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_685ff28b91508327ba905004c72b7a58