### PR TITLE
Add executable_names metadata field

### DIFF
--- a/alembic/versions/ff1e00581431_add_executable_names_to_metadata.py
+++ b/alembic/versions/ff1e00581431_add_executable_names_to_metadata.py
@@ -1,0 +1,31 @@
+"""Add executable_names column to Metadata
+
+Revision ID: ff1e00581431
+Revises: 206456dfa91c
+Create Date: 2025-07-01 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "ff1e00581431"
+down_revision: Union[str, Sequence[str], None] = "206456dfa91c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "metadata",
+        sa.Column("executable_names", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("metadata", "executable_names")

--- a/src/app/database.py
+++ b/src/app/database.py
@@ -142,11 +142,16 @@ def update_package_status(package_id: Union[str, UUID], status: str) -> bool:
         session.close()
 
 
-def create_metadata(package_id: Union[str, UUID], **metadata_fields: Any) -> Metadata:
+def create_metadata(
+    package_id: Union[str, UUID],
+    executable_names: Optional[list[str]] | None = None,
+    **metadata_fields: Any,
+) -> Metadata:
     """Create metadata for a package.
 
     Args:
         package_id: UUID string of the package
+        executable_names: Optional list of executable names associated with the package
         **metadata_fields: Metadata field values
 
     Returns:
@@ -156,7 +161,11 @@ def create_metadata(package_id: Union[str, UUID], **metadata_fields: Any) -> Met
 
     session = db_service.get_session()
     try:
-        metadata = Metadata(package_id=to_uuid(package_id), **metadata_fields)
+        metadata = Metadata(
+            package_id=to_uuid(package_id),
+            executable_names=executable_names,
+            **metadata_fields,
+        )
         session.add(metadata)
         session.commit()
         session.refresh(metadata)

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -45,7 +45,6 @@ class Package(Base):
     # User input
     custom_instructions: Mapped[Optional[str]] = mapped_column(Text)
 
-
     # 5-Stage Pipeline Results
     generated_script: Mapped[Optional[dict]] = mapped_column(JSON)
     hallucination_report: Mapped[Optional[dict]] = mapped_column(JSON)
@@ -89,6 +88,7 @@ class Metadata(Base):
     upgrade_code: Mapped[Optional[str]] = mapped_column(String(100))
     language: Mapped[Optional[str]] = mapped_column(String(50))
     architecture: Mapped[Optional[str]] = mapped_column(String(20))
+    executable_names: Mapped[Optional[list]] = mapped_column(JSON)
 
     # Relationship to package
     package: Mapped["Package"] = relationship(

--- a/src/app/routes.py
+++ b/src/app/routes.py
@@ -368,6 +368,7 @@ def register_routes(app: Flask) -> None:
                     upgrade_code=metadata_dict.get("upgrade_code"),
                     language=metadata_dict.get("language"),
                     architecture=metadata_dict.get("architecture"),
+                    executable_names=metadata_dict.get("executable_names"),
                 )
                 package_logger.log_step(
                     "DATABASE_STORAGE", "Metadata stored successfully"

--- a/tests/test_metadata_integration.py
+++ b/tests/test_metadata_integration.py
@@ -112,6 +112,7 @@ def test_create_metadata_function_with_individual_fields():
             publisher="Test Company",
             architecture="x64",
             product_code="{12345678-1234-1234-1234-123456789012}",
+            executable_names=["app.exe"],
         )
 
         # Verify metadata was saved correctly
@@ -120,9 +121,11 @@ def test_create_metadata_function_with_individual_fields():
         assert metadata.publisher == "Test Company"
         assert metadata.architecture == "x64"
         assert metadata.product_code == "{12345678-1234-1234-1234-123456789012}"
+        assert metadata.executable_names == ["app.exe"]
 
         # Verify relationship works
         retrieved_package = get_package(str(package.id))
         assert retrieved_package is not None
         assert retrieved_package.package_metadata is not None
         assert retrieved_package.package_metadata.product_name == "Test Application"
+        assert retrieved_package.package_metadata.executable_names == ["app.exe"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -108,6 +108,7 @@ class TestMetadataModel:
             install_date="2025-01-01",
             uninstall_string="msiexec /x {GUID}",
             estimated_size=1024,
+            executable_names=["setup.exe"],
         )
 
         session.add(metadata)
@@ -122,6 +123,7 @@ class TestMetadataModel:
         assert metadata.install_date == "2025-01-01"
         assert metadata.uninstall_string == "msiexec /x {GUID}"
         assert metadata.estimated_size == 1024
+        assert metadata.executable_names == ["setup.exe"]
 
     def test_package_metadata_relationship(self, session):
         """Test relationship between Package and Metadata."""


### PR DESCRIPTION
## Summary
- support recording executable names in `Metadata` model
- add Alembic migration for new column
- allow `create_metadata` to accept executable_names
- store executable_names from upload route
- test executable_names persistence

## Testing
- `pytest tests/test_models.py::TestMetadataModel::test_metadata_creation -q`
- `pytest tests/test_metadata_integration.py::test_create_metadata_function_with_individual_fields -q`
- `pytest -q` *(fails: RuntimeError: Unable to build URLs outside an active request)*

------
https://chatgpt.com/codex/tasks/task_e_685ff28928d48327b81ad844def6591d